### PR TITLE
Update notifications empty state copy (NOS-170)

### DIFF
--- a/src/notifications/NotificationDrawer.tsx
+++ b/src/notifications/NotificationDrawer.tsx
@@ -87,10 +87,7 @@ export function NotificationDrawer() {
             ) : (
               <div className="text-center py-8 text-gray-500">
                 <Bell className="h-12 w-12 mx-auto mb-4 text-gray-300" />
-                <p>No new notifications</p>
-                <p className="text-sm text-gray-400 mt-1">
-                  Share a quick action above to create some neighborhood activity and notifications!
-                </p>
+                <p>When someone interacts with you, you'll receive notifications here.</p>
               </div>
             )}
           </div>

--- a/src/notifications/NotificationsList.tsx
+++ b/src/notifications/NotificationsList.tsx
@@ -122,13 +122,12 @@ export function NotificationsList() {
               return (
                 <div className="text-center py-8 text-gray-500">
                   <Bell className="h-12 w-12 mx-auto mb-4 text-gray-300" />
-                  <p>{showArchived ? 'No archived notifications' : 'No new notifications'}</p>
-                  <p className="text-sm text-gray-400 mt-1">
-                    {showArchived 
-                      ? 'You haven\'t archived any notifications'
-                      : 'Share a quick action above to create some neighborhood activity and notifications!'
-                    }
-                  </p>
+                  <p>{showArchived ? 'No archived notifications' : 'When someone interacts with you, you\'ll receive notifications here.'}</p>
+                  {showArchived && (
+                    <p className="text-sm text-gray-400 mt-1">
+                      You haven't archived any notifications
+                    </p>
+                  )}
                 </div>
               );
             }


### PR DESCRIPTION
# Update notifications empty state copy (NOS-170)

## Summary
Updated the empty state copy for notifications from a two-line message to a single, clearer message: "When someone interacts with you, you'll receive notifications here." 

Changes made to both `NotificationsList.tsx` and `NotificationDrawer.tsx` while preserving the Bell icon styling and maintaining the conditional logic for archived notifications.

## Review & Testing Checklist for Human
- [ ] Verify the regular notifications empty state displays the new copy correctly in both components
- [ ] Test that archived notifications empty state still shows "No archived notifications" + "You haven't archived any notifications" 
- [ ] Check visual spacing and alignment looks good with single line instead of two lines

### Notes
This is a simple copy change but requires visual verification since local testing wasn't possible due to environment dependencies. The conditional logic for archived vs regular notifications was preserved.

**Link to Devin run**: https://app.devin.ai/sessions/185be23f87b944b1b90f184003d9d0c7  
**Requested by**: Cam Lindsay (@camsinit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Simplified empty-state copy in Notification Drawer and Notifications List.
  - Non-archived view now shows: “When someone interacts with you, you'll receive notifications here.”
  - Archived view now shows: “No archived notifications.” with a secondary line: “You haven't archived any notifications.”
  - Removed previous secondary tips and guidance text.
- Chores
  - No functional or API changes; loading, list rendering, and header actions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->