### PR TITLE
Remove goods and safety from newsletter

### DIFF
--- a/src/utils/email/urlGenerator.ts
+++ b/src/utils/email/urlGenerator.ts
@@ -31,14 +31,6 @@ export const getEventsLink = (): string => {
   return `${getEmailBaseUrl()}/events`;
 };
 
-export const getFreebiesLink = (): string => {
-  return `${getEmailBaseUrl()}/goods`;
-};
-
-export const getUpdatesLink = (): string => {
-  return `${getEmailBaseUrl()}/safety`;
-};
-
 export const getDirectoryLink = (): string => {
   return `${getEmailBaseUrl()}/neighbors`;
 };
@@ -97,14 +89,6 @@ export const getWeeklySummaryEventsURL = (): string => {
 
 export const getWeeklySummarySkillsURL = (): string => {
   return addEmailTrackingParams(getSkillsLink(), "weekly_summary_skills", "email");
-};
-
-export const getWeeklySummaryGoodsURL = (): string => {
-  return addEmailTrackingParams(getFreebiesLink(), "weekly_summary_goods", "email");
-};
-
-export const getWeeklySummarySafetyURL = (): string => {
-  return addEmailTrackingParams(getUpdatesLink(), "weekly_summary_safety", "email");
 };
 
 export const getWeeklySummarySettingsURL = (): string => {

--- a/supabase/functions/send-onboarding-email/index.ts
+++ b/supabase/functions/send-onboarding-email/index.ts
@@ -54,14 +54,6 @@ const getSkillsLink = (): string => {
   return `${getEmailBaseUrl()}/skills`;
 };
 
-const getFreebiesLink = (): string => {
-  return `${getEmailBaseUrl()}/goods`;
-};
-
-const getUpdatesLink = (): string => {
-  return `${getEmailBaseUrl()}/safety`;
-};
-
 const getDirectoryLink = (): string => {
   return `${getEmailBaseUrl()}/neighbors`;
 };

--- a/supabase/functions/send-weekly-summary-final/_utils/urlGenerator.ts
+++ b/supabase/functions/send-weekly-summary-final/_utils/urlGenerator.ts
@@ -31,14 +31,6 @@ export const getWeeklySummarySkillsURL = (): string => {
   return addEmailTrackingParams(`${getEmailBaseUrl()}/skills`, "weekly_summary_skills", "email");
 };
 
-export const getWeeklySummaryGoodsURL = (): string => {
-  return addEmailTrackingParams(`${getEmailBaseUrl()}/goods`, "weekly_summary_goods", "email");
-};
-
-export const getWeeklySummarySafetyURL = (): string => {
-  return addEmailTrackingParams(`${getEmailBaseUrl()}/safety`, "weekly_summary_safety", "email");
-};
-
 export const getWeeklySummaryDashboardURL = (): string => {
   return addEmailTrackingParams(`${getEmailBaseUrl()}/dashboard`, "weekly_summary_dashboard", "email");
 };
@@ -58,11 +50,6 @@ export const getEventURL = (neighborhoodId: string, eventId: string): string => 
   return addEmailTrackingParams(url, "weekly_summary_event", "email");
 };
 
-export const getGoodsURL = (neighborhoodId: string, goodsId: string): string => {
-  const url = `${getEmailBaseUrl()}/n/${neighborhoodId}/goods?highlight=goods&type=goods_exchange&id=${goodsId}`;
-  return addEmailTrackingParams(url, "weekly_summary_goods_item", "email");
-};
-
 export const getSkillURL = (neighborhoodId: string, skillId: string, category?: string): string => {
   let url = `${getEmailBaseUrl()}/n/${neighborhoodId}/skills?highlight=skill&type=skills_exchange&id=${skillId}`;
   if (category) {
@@ -74,11 +61,6 @@ export const getSkillURL = (neighborhoodId: string, skillId: string, category?: 
 export const getGroupURL = (neighborhoodId: string, groupId: string): string => {
   const url = `${getEmailBaseUrl()}/n/${neighborhoodId}/groups?highlight=${groupId}&type=group&dialog=true`;
   return addEmailTrackingParams(url, "weekly_summary_group", "email");
-};
-
-export const getSafetyURL = (neighborhoodId: string, safetyId: string): string => {
-  const url = `${getEmailBaseUrl()}/n/${neighborhoodId}/safety?highlight=safety&type=safety_updates&id=${safetyId}`;
-  return addEmailTrackingParams(url, "weekly_summary_safety_item", "email");
 };
 
 /**

--- a/supabase/functions/send-weekly-summary-final/index.ts
+++ b/supabase/functions/send-weekly-summary-final/index.ts
@@ -111,14 +111,15 @@ async function generateAIContent(neighborhoodName: string, stats: any, highlight
     console.log('❌ No Claude API key found, using default content');
     const createEventUrl = `https://neighborhoodos.com/n/${neighborhoodId}/calendar?create=true`;
     const createSkillUrl = `https://neighborhoodos.com/n/${neighborhoodId}/skills?create=true`;
+    const createGroupUrl = `https://neighborhoodos.com/n/${neighborhoodId}/groups?create=true`;
 
     return {
       thisWeek: "This past week brought new connections and community activity. Thank you to everyone who participated in making our neighborhood more vibrant.",
       weekAhead: "The calendar is wide open this week! Check out the suggestions below to help fill next week's newsletter with exciting events.",
       getInvolved: [
-        `<a href="${createEventUrl}">Organize a beat-making workshop</a> where neighbors can learn to create their own tracks.`,
-        `<a href="${createSkillUrl}">Coordinate a bulk cooking group</a> to share ingredients and recipes.`,
-        `<a href="${createEventUrl}">Host a tech support session</a> to help neighbors with WiFi troubleshooting and computer help.`
+        `<a href="${createEventUrl}">Since Parker offers electronic music production, organize a beat-making workshop</a> where neighbors can learn to create their own tracks.`,
+        `<a href="${createSkillUrl}">With Pamela's Costco expertise and Laura's meal exchanges, coordinate a bulk cooking group</a> to share ingredients and recipes.`,
+        `<a href="${createGroupUrl}">Parker's tech skills (WiFi troubleshooting, computer help) could launch a neighborhood tech support circle</a>.`
       ]
     };
   }
@@ -209,6 +210,7 @@ REQUIREMENTS:
 - Include natural links:
   * Events: ${createEventUrl}
   * Skills: ${createSkillUrl}
+  * Groups: ${createGroupUrl}
 - No em-dashes (—), use regular hyphens only
 - Friendly but not overly excited
 
@@ -273,6 +275,7 @@ Return as JSON array: ["suggestion 1", "suggestion 2", "suggestion 3"]`;
       // Return default content with dynamic suggestions structure
       const createEventUrl = `https://neighborhoodos.com/n/${neighborhoodId}/calendar?create=true`;
       const createSkillUrl = `https://neighborhoodos.com/n/${neighborhoodId}/skills?create=true`;
+      const createGroupUrl = `https://neighborhoodos.com/n/${neighborhoodId}/groups?create=true`;
 
       return {
         thisWeek: newNeighbors.length > 0 ?
@@ -280,9 +283,9 @@ Return as JSON array: ["suggestion 1", "suggestion 2", "suggestion 3"]`;
           "This past week brought new connections and community activity. Thank you to everyone who participated in making our neighborhood more vibrant.",
         weekAhead: "The calendar is wide open this week! Check out the suggestions below to help fill next week's newsletter with exciting events.",
         getInvolved: [
-          `<a href="${createEventUrl}">Organize a beat-making workshop</a> where neighbors can learn to create their own tracks.`,
-          `<a href="${createSkillUrl}">Coordinate a bulk cooking group</a> to share ingredients and recipes.`,
-          `<a href="${createEventUrl}">Host a tech support session</a> to help neighbors with WiFi troubleshooting and computer help.`
+          `<a href="${createEventUrl}">Since Parker offers electronic music production, organize a beat-making workshop</a> where neighbors can learn to create their own tracks.`,
+          `<a href="${createSkillUrl}">With Pamela's Costco expertise and Laura's meal exchanges, coordinate a bulk cooking group</a> to share ingredients and recipes.`,
+          `<a href="${createGroupUrl}">Parker's tech skills (WiFi troubleshooting, computer help) could launch a neighborhood tech support circle</a>.`
         ]
       };
     }
@@ -292,6 +295,7 @@ Return as JSON array: ["suggestion 1", "suggestion 2", "suggestion 3"]`;
     // Return default content with dynamic suggestions structure
     const createEventUrl = `https://neighborhoodos.com/n/${neighborhoodId}/calendar?create=true`;
     const createSkillUrl = `https://neighborhoodos.com/n/${neighborhoodId}/skills?create=true`;
+    const createGroupUrl = `https://neighborhoodos.com/n/${neighborhoodId}/groups?create=true`;
 
     return {
       thisWeek: newNeighbors.length > 0 ?
@@ -299,9 +303,9 @@ Return as JSON array: ["suggestion 1", "suggestion 2", "suggestion 3"]`;
         "This past week brought new connections and community activity. Thank you to everyone who participated in making our neighborhood more vibrant.",
       weekAhead: "The calendar is wide open this week! Check out the suggestions below to help fill next week's newsletter with exciting events.",
       getInvolved: [
-        `<a href="${createEventUrl}">Organize a beat-making workshop</a> where neighbors can learn to create their own tracks.`,
-        `<a href="${createSkillUrl}">Coordinate a bulk cooking group</a> to share ingredients and recipes.`,
-        `<a href="${createEventUrl}">Host a tech support session</a> to help neighbors with WiFi troubleshooting and computer help.`
+        `<a href="${createEventUrl}">Since Parker offers electronic music production, organize a beat-making workshop</a> where neighbors can learn to create their own tracks.`,
+        `<a href="${createSkillUrl}">With Pamela's Costco expertise and Laura's meal exchanges, coordinate a bulk cooking group</a> to share ingredients and recipes.`,
+        `<a href="${createGroupUrl}">Parker's tech skills (WiFi troubleshooting, computer help) could launch a neighborhood tech support circle</a>.`
       ]
     };
   }

--- a/supabase/functions/send-weekly-summary-final/index.ts
+++ b/supabase/functions/send-weekly-summary-final/index.ts
@@ -111,15 +111,14 @@ async function generateAIContent(neighborhoodName: string, stats: any, highlight
     console.log('❌ No Claude API key found, using default content');
     const createEventUrl = `https://neighborhoodos.com/n/${neighborhoodId}/calendar?create=true`;
     const createSkillUrl = `https://neighborhoodos.com/n/${neighborhoodId}/skills?create=true`;
-    const createGroupUrl = `https://neighborhoodos.com/n/${neighborhoodId}/groups?create=true`;
-    
+
     return {
       thisWeek: "This past week brought new connections and community activity. Thank you to everyone who participated in making our neighborhood more vibrant.",
       weekAhead: "The calendar is wide open this week! Check out the suggestions below to help fill next week's newsletter with exciting events.",
       getInvolved: [
-        `<a href="${createEventUrl}">Since Parker offers electronic music production, organize a beat-making workshop</a> where neighbors can learn to create their own tracks.`,
-        `<a href="${createSkillUrl}">With Pamela's Costco expertise and Laura's meal exchanges, coordinate a bulk cooking group</a> to share ingredients and recipes.`,
-        `<a href="${createGroupUrl}">Parker's tech skills (WiFi troubleshooting, computer help) could launch a neighborhood tech support circle</a>.`
+        `<a href="${createEventUrl}">Organize a beat-making workshop</a> where neighbors can learn to create their own tracks.`,
+        `<a href="${createSkillUrl}">Coordinate a bulk cooking group</a> to share ingredients and recipes.`,
+        `<a href="${createEventUrl}">Host a tech support session</a> to help neighbors with WiFi troubleshooting and computer help.`
       ]
     };
   }
@@ -210,7 +209,6 @@ REQUIREMENTS:
 - Include natural links:
   * Events: ${createEventUrl}
   * Skills: ${createSkillUrl}
-  * Groups: ${createGroupUrl}
 - No em-dashes (—), use regular hyphens only
 - Friendly but not overly excited
 
@@ -275,7 +273,6 @@ Return as JSON array: ["suggestion 1", "suggestion 2", "suggestion 3"]`;
       // Return default content with dynamic suggestions structure
       const createEventUrl = `https://neighborhoodos.com/n/${neighborhoodId}/calendar?create=true`;
       const createSkillUrl = `https://neighborhoodos.com/n/${neighborhoodId}/skills?create=true`;
-      const createGroupUrl = `https://neighborhoodos.com/n/${neighborhoodId}/groups?create=true`;
 
       return {
         thisWeek: newNeighbors.length > 0 ?
@@ -283,9 +280,9 @@ Return as JSON array: ["suggestion 1", "suggestion 2", "suggestion 3"]`;
           "This past week brought new connections and community activity. Thank you to everyone who participated in making our neighborhood more vibrant.",
         weekAhead: "The calendar is wide open this week! Check out the suggestions below to help fill next week's newsletter with exciting events.",
         getInvolved: [
-          `<a href="${createEventUrl}">Since Parker offers electronic music production, organize a beat-making workshop</a> where neighbors can learn to create their own tracks.`,
-          `<a href="${createSkillUrl}">With Pamela's Costco expertise and Laura's meal exchanges, coordinate a bulk cooking group</a> to share ingredients and recipes.`,
-          `<a href="${createGroupUrl}">Parker's tech skills (WiFi troubleshooting, computer help) could launch a neighborhood tech support circle</a>.`
+          `<a href="${createEventUrl}">Organize a beat-making workshop</a> where neighbors can learn to create their own tracks.`,
+          `<a href="${createSkillUrl}">Coordinate a bulk cooking group</a> to share ingredients and recipes.`,
+          `<a href="${createEventUrl}">Host a tech support session</a> to help neighbors with WiFi troubleshooting and computer help.`
         ]
       };
     }
@@ -295,17 +292,16 @@ Return as JSON array: ["suggestion 1", "suggestion 2", "suggestion 3"]`;
     // Return default content with dynamic suggestions structure
     const createEventUrl = `https://neighborhoodos.com/n/${neighborhoodId}/calendar?create=true`;
     const createSkillUrl = `https://neighborhoodos.com/n/${neighborhoodId}/skills?create=true`;
-    const createGroupUrl = `https://neighborhoodos.com/n/${neighborhoodId}/groups?create=true`;
-    
+
     return {
       thisWeek: newNeighbors.length > 0 ?
         `Welcome to our newest neighbors: ${newNeighbors.map(n => `<a href="${n.profileUrl}">${n.name}</a>`).join(', ')}! This week brought new connections and community activity.` :
         "This past week brought new connections and community activity. Thank you to everyone who participated in making our neighborhood more vibrant.",
       weekAhead: "The calendar is wide open this week! Check out the suggestions below to help fill next week's newsletter with exciting events.",
       getInvolved: [
-        `<a href="${createEventUrl}">Since Parker offers electronic music production, organize a beat-making workshop</a> where neighbors can learn to create their own tracks.`,
-        `<a href="${createSkillUrl}">With Pamela's Costco expertise and Laura's meal exchanges, coordinate a bulk cooking group</a> to share ingredients and recipes.`,
-        `<a href="${createGroupUrl}">Parker's tech skills (WiFi troubleshooting, computer help) could launch a neighborhood tech support circle</a>.`
+        `<a href="${createEventUrl}">Organize a beat-making workshop</a> where neighbors can learn to create their own tracks.`,
+        `<a href="${createSkillUrl}">Coordinate a bulk cooking group</a> to share ingredients and recipes.`,
+        `<a href="${createEventUrl}">Host a tech support session</a> to help neighbors with WiFi troubleshooting and computer help.`
       ]
     };
   }

--- a/supabase/functions/send-weekly-summary-final/index.ts
+++ b/supabase/functions/send-weekly-summary-final/index.ts
@@ -128,22 +128,17 @@ async function generateAIContent(neighborhoodName: string, stats: any, highlight
 
   try {
     // Calculate total activity count to detect low-activity periods
-    const totalActivities = 
-      pastWeekActivities.completedEvents.length + 
-      pastWeekActivities.archivedGoods.length + 
-      pastWeekActivities.completedSkills.length + 
-      pastWeekActivities.safetyUpdates.length +
-      upcomingActivities.events.length + 
-      upcomingActivities.skills.length + 
-      upcomingActivities.goods.length;
+    const totalActivities =
+      pastWeekActivities.completedEvents.length +
+      pastWeekActivities.completedSkills.length +
+      upcomingActivities.events.length +
+      upcomingActivities.skills.length;
     
     const isLowActivity = totalActivities <= 2; // Consider 2 or fewer activities as "low"
     
     // Create activity URLs for easy posting (using the same URL generation pattern)
     const createEventUrl = `https://neighborhoodos.com/n/${neighborhoodId}/calendar?create=true`;
     const createSkillUrl = `https://neighborhoodos.com/n/${neighborhoodId}/skills?create=true`;
-    const createGoodsUrl = `https://neighborhoodos.com/n/${neighborhoodId}/goods?create=true`;
-    const createSafetyUrl = `https://neighborhoodos.com/n/${neighborhoodId}/safety?create=true`;
     
     // Get current date for seasonal context
     const currentDate = new Date();


### PR DESCRIPTION
## Summary
- Simplified newsletter to focus only on events and skills
- Removed references to goods exchange and safety updates from activity calculations
- Removed unused URL generators for goods and safety pages

## Context
The newsletter was tracking goods and safety activities that aren't core to the weekly digest. This change ensures the newsletter is a clean snapshot of events and skills only.

## Changes
- Removed `archivedGoods`, `safetyUpdates`, and `upcomingActivities.goods` from total activity count
- Removed `createGoodsUrl` and `createSafetyUrl` variables
- Added `replyTo` field to all email sending functions for better support
- Fixed invitation email to show different copy for admin vs regular invites

## Test plan
- [ ] Verify newsletter preview shows only events and skills
- [ ] Test newsletter sending with test email
- [ ] Confirm activity count calculation works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Weekly summaries now count only completed/upcoming events and skills; goods/safety activities removed from the total. Suggestions focus on events, skills, and groups.

* **Bug Fixes**
  * Low-activity detection updated to use the simplified activity total (events and skills only).

* **Chores**
  * Onboarding and weekly emails updated to omit goods/safety creation links and related public URL generators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->